### PR TITLE
removed throwing chat list to console

### DIFF
--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -75,7 +75,7 @@ export default class ChatList {
     this.$chat_rooms_container = $(document.createElement('div'));
     this.$chat_rooms_container.addClass('chat-rooms-container');
     this.chat_rooms = [];
-    console.log(this.rooms)
+    //console.log(this.rooms)
     this.rooms.forEach((element) => {
       let profile = {
         user: this.user,


### PR DESCRIPTION
Whatsapp chat list are thrown in to console during any page load.
<img width="1852" height="103" alt="image" src="https://github.com/user-attachments/assets/6d46146a-c89a-4282-8d40-64a199672273" />

I identified a console.log in the `chat_list.js` file and commented it.